### PR TITLE
Removed logging of commands 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/events/guild/message.js
+++ b/events/guild/message.js
@@ -42,7 +42,7 @@ module.exports = async (bot, message) => {
         var commandfile = bot.commands.get(cmd) || bot.commands.get(bot.aliases.get(cmd))
          if (commandfile){
              
-            console.log(commandfile) //console.log the usage of commands
+            
         
             commandfile.run(bot, message, args, ops)
         }


### PR DESCRIPTION
Logging command usage is quite stupid and will put unwanted stress on the machine if the bot is simultaneously called in numerous servers.
Added a classic `.gitignore` to make the development process a bit easier.